### PR TITLE
FIX: Correct all_time zh_TW translation to "所有時間"

### DIFF
--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -2308,7 +2308,7 @@ zh_TW:
           title: "周"
         daily:
           title: "日"
-        all_time: "所以時間"
+        all_time: "所有時間"
         this_year: "年"
         this_quarter: "季度"
         this_month: "月"


### PR DESCRIPTION
all_time's proper zh_TW translation should be 所有時間 rather than 所以時間

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
